### PR TITLE
Adds utterance progress notifications for API < 21 and fixes onStart race condition.

### DIFF
--- a/library/src/main/java/com/mapzen/speakerbox/Speakerbox.java
+++ b/library/src/main/java/com/mapzen/speakerbox/Speakerbox.java
@@ -265,7 +265,9 @@ public class Speakerbox implements TextToSpeech.OnInitListener {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             textToSpeech.speak(text, queueMode, null, utteranceId);
         } else {
-            textToSpeech.speak(text, queueMode, null);
+            final HashMap<String, String> params = new HashMap<>();
+            params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceId);
+            textToSpeech.speak(text, queueMode, params);
         }
     }
 

--- a/library/src/test/java/com/mapzen/speakerbox/ShadowTextToSpeech.java
+++ b/library/src/test/java/com/mapzen/speakerbox/ShadowTextToSpeech.java
@@ -19,7 +19,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
+import android.speech.tts.UtteranceProgressListener;
 
 import java.util.HashMap;
 
@@ -33,6 +35,9 @@ public class ShadowTextToSpeech {
     private boolean stopped = false;
     private boolean isSpeaking = false;
     private int queueMode = -1;
+    private UtteranceProgressListener utteranceProgressListener;
+    private boolean finishOnSpeak = false;
+    private boolean errorOnSpeak = false;
 
     public void __constructor__(Context context, TextToSpeech.OnInitListener listener) {
         this.context = context;
@@ -52,6 +57,30 @@ public class ShadowTextToSpeech {
         lastSpokenText = text;
         this.queueMode = queueMode;
         isSpeaking = true;
+        return TextToSpeech.SUCCESS;
+    }
+
+    @Implementation
+    public int speak(final CharSequence text,
+            final int queueMode,
+            final Bundle params,
+            final String utteranceId) {
+        lastSpokenText = text.toString();
+        this.queueMode = queueMode;
+        isSpeaking = true;
+        utteranceProgressListener.onStart(utteranceId);
+        if (finishOnSpeak) {
+            utteranceProgressListener.onDone(utteranceId);
+        }
+        if (errorOnSpeak) {
+            utteranceProgressListener.onError(utteranceId);
+        }
+        return TextToSpeech.SUCCESS;
+    }
+
+    @Implementation
+    public int setOnUtteranceProgressListener(UtteranceProgressListener listener) {
+        utteranceProgressListener = listener;
         return TextToSpeech.SUCCESS;
     }
 
@@ -88,5 +117,13 @@ public class ShadowTextToSpeech {
 
     public boolean isSpeaking() {
         return isSpeaking;
+    }
+
+    public void setFinishOnSpeak(boolean finishOnSpeak) {
+        this.finishOnSpeak = finishOnSpeak;
+    }
+
+    public void setErrorOnSpeak(boolean errorOnSpeak) {
+        this.errorOnSpeak = errorOnSpeak;
     }
 }

--- a/library/src/test/java/com/mapzen/speakerbox/ShadowTextToSpeech.java
+++ b/library/src/test/java/com/mapzen/speakerbox/ShadowTextToSpeech.java
@@ -57,6 +57,8 @@ public class ShadowTextToSpeech {
         lastSpokenText = text;
         this.queueMode = queueMode;
         isSpeaking = true;
+        final String utteranceId = params.get(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID);
+        notifyProgressListener(utteranceId);
         return TextToSpeech.SUCCESS;
     }
 
@@ -68,13 +70,7 @@ public class ShadowTextToSpeech {
         lastSpokenText = text.toString();
         this.queueMode = queueMode;
         isSpeaking = true;
-        utteranceProgressListener.onStart(utteranceId);
-        if (finishOnSpeak) {
-            utteranceProgressListener.onDone(utteranceId);
-        }
-        if (errorOnSpeak) {
-            utteranceProgressListener.onError(utteranceId);
-        }
+        notifyProgressListener(utteranceId);
         return TextToSpeech.SUCCESS;
     }
 
@@ -125,5 +121,15 @@ public class ShadowTextToSpeech {
 
     public void setErrorOnSpeak(boolean errorOnSpeak) {
         this.errorOnSpeak = errorOnSpeak;
+    }
+
+    private void notifyProgressListener(String utteranceId) {
+        utteranceProgressListener.onStart(utteranceId);
+        if (finishOnSpeak) {
+            utteranceProgressListener.onDone(utteranceId);
+        }
+        if (errorOnSpeak) {
+            utteranceProgressListener.onError(utteranceId);
+        }
     }
 }

--- a/library/src/test/java/com/mapzen/speakerbox/SpeakerboxTest.java
+++ b/library/src/test/java/com/mapzen/speakerbox/SpeakerboxTest.java
@@ -244,7 +244,7 @@ public class SpeakerboxTest {
     }
 
     @Test @Config(sdk = 21)
-    public void playAndOnStart_shouldNotifyOnStart() throws Exception {
+    public void playAndOnStart_shouldNotifyOnStart_Api21() throws Exception {
         final OnStartListener onStartListener = new OnStartListener();
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
         speakerbox.playAndOnStart("Yo", new Runnable() {
@@ -256,7 +256,7 @@ public class SpeakerboxTest {
     }
 
     @Test @Config(sdk = 21)
-    public void playAndOnDone_shouldNotifyOnDone() throws Exception {
+    public void playAndOnDone_shouldNotifyOnDone_Api21() throws Exception {
         final OnDoneListener onDoneListener = new OnDoneListener();
         shadowTextToSpeech.setFinishOnSpeak(true);
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
@@ -269,7 +269,45 @@ public class SpeakerboxTest {
     }
 
     @Test @Config(sdk = 21)
-    public void playAndOnError_shouldNotifyOnError() throws Exception {
+    public void playAndOnError_shouldNotifyOnError_Api21() throws Exception {
+        final OnErrorListener onErrorListener = new OnErrorListener();
+        shadowTextToSpeech.setErrorOnSpeak(true);
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnError("Yo", new Runnable() {
+            @Override public void run() {
+                onErrorListener.onError = true;
+            }
+        });
+        assertThat(onErrorListener.onError).isTrue();
+    }
+
+    @Test @Config(sdk = 19)
+    public void playAndOnStart_shouldNotifyOnStart_Api19() throws Exception {
+        final OnStartListener onStartListener = new OnStartListener();
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnStart("Yo", new Runnable() {
+            @Override public void run() {
+                onStartListener.onStart = true;
+            }
+        });
+        assertThat(onStartListener.onStart).isTrue();
+    }
+
+    @Test @Config(sdk = 19)
+    public void playAndOnDone_shouldNotifyOnDone_Api19() throws Exception {
+        final OnDoneListener onDoneListener = new OnDoneListener();
+        shadowTextToSpeech.setFinishOnSpeak(true);
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnDone("Yo", new Runnable() {
+            @Override public void run() {
+                onDoneListener.onDone = true;
+            }
+        });
+        assertThat(onDoneListener.onDone).isTrue();
+    }
+
+    @Test @Config(sdk = 19)
+    public void playAndOnError_shouldNotifyOnError_Api19() throws Exception {
         final OnErrorListener onErrorListener = new OnErrorListener();
         shadowTextToSpeech.setErrorOnSpeak(true);
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);

--- a/library/src/test/java/com/mapzen/speakerbox/SpeakerboxTest.java
+++ b/library/src/test/java/com/mapzen/speakerbox/SpeakerboxTest.java
@@ -242,4 +242,54 @@ public class SpeakerboxTest {
         speakerbox.play("Yo");
         assertThat(shadowTextToSpeech.getQueueMode()).isEqualTo(TextToSpeech.QUEUE_ADD);
     }
+
+    @Test @Config(sdk = 21)
+    public void playAndOnStart_shouldNotifyOnStart() throws Exception {
+        final OnStartListener onStartListener = new OnStartListener();
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnStart("Yo", new Runnable() {
+            @Override public void run() {
+                onStartListener.onStart = true;
+            }
+        });
+        assertThat(onStartListener.onStart).isTrue();
+    }
+
+    @Test @Config(sdk = 21)
+    public void playAndOnDone_shouldNotifyOnDone() throws Exception {
+        final OnDoneListener onDoneListener = new OnDoneListener();
+        shadowTextToSpeech.setFinishOnSpeak(true);
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnDone("Yo", new Runnable() {
+            @Override public void run() {
+                onDoneListener.onDone = true;
+            }
+        });
+        assertThat(onDoneListener.onDone).isTrue();
+    }
+
+    @Test @Config(sdk = 21)
+    public void playAndOnError_shouldNotifyOnError() throws Exception {
+        final OnErrorListener onErrorListener = new OnErrorListener();
+        shadowTextToSpeech.setErrorOnSpeak(true);
+        speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD);
+        speakerbox.playAndOnError("Yo", new Runnable() {
+            @Override public void run() {
+                onErrorListener.onError = true;
+            }
+        });
+        assertThat(onErrorListener.onError).isTrue();
+    }
+
+    class OnStartListener {
+        boolean onStart = false;
+    }
+
+    class OnDoneListener {
+        boolean onDone = false;
+    }
+
+    class OnErrorListener {
+        boolean onError = false;
+    }
 }


### PR DESCRIPTION
* Fixes race condition created by sending text to the TTS engine before adding the `onStart` progress `Runnable` to the `HashMap`. Now all progress `Runnable` objects are registered _before_ text is sent to the engine.
* Implements progress callbacks for API < 21 using parameter `HashMap` with `KEY_PARAM_UTTERANCE_ID` when calling deprecated version of `speak(...)` method.
* Adds unit tests for API 21 and API 19 callbacks. Updates `ShadowTextToSpeech`.

TODO: Implement progress callbacks for text that is sent to `Speakerbox` before TTS Engine initialization is complete. Currently any `Runnable` objects associated with `playOnInit` are lost.